### PR TITLE
Ground work for making keys configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92fbd0445bda1ac099b76a3fbad67668f915f1873cc1d9b47c02889211fa1ace"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +175,7 @@ dependencies = [
 name = "sapling"
 version = "0.1.0"
 dependencies = [
+ "hmap",
  "tuikit",
  "typed-arena",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 tuikit = "*"
 typed-arena = "2.0.1"
+hmap = "0.1.0"

--- a/src/editable_tree/mod.rs
+++ b/src/editable_tree/mod.rs
@@ -6,7 +6,7 @@ use crate::arena::Arena;
 use crate::ast::Ast;
 
 /// The possible ways you can move the cursor
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub enum Direction {
     Up,
     Down,

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,6 @@ fn main() {
     .add_to_arena(&arena);
 
     let mut tree = DAG::new(&arena, root);
-    let editor = Editor::new(&mut tree, JSONFormat::Pretty);
+    let editor = Editor::new(&mut tree, JSONFormat::Pretty, editor::default_keymap());
     editor.run();
 }


### PR DESCRIPTION
This change introduces an abstraction between chars and `Action` which
allows for run-time configuration of key mapping. Loading the map from a
file is not implemented here since no configuration exists yet.