### PR TITLE
Fix vanishing cursor

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -430,6 +430,10 @@ impl<'arena, Node: Ast<'arena> + 'arena, E: EditableTree<'arena, Node> + 'arena>
         self.log(LogLevel::Info, "Starting Up...".to_string());
         // Start the mainloop
         self.mainloop();
+        // Show the cursor before closing so that the cursor isn't permanently disabled
+        // (see issue https://github.com/lotabout/tuikit/issues/28)
+        self.term.show_cursor(true).unwrap();
+        self.term.present().unwrap();
         // Log that the editor is closing
         self.log(LogLevel::Info, "Closing...".to_string());
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -65,7 +65,7 @@ pub fn default_keymap() -> KeyMap {
         'q' => Command::Quit,
         'i' => Command::InsertChild,
         'r' => Command::Replace,
-        'c' => Command::MoveCursor(Direction::Down), 
+        'c' => Command::MoveCursor(Direction::Down),
         'p' => Command::MoveCursor(Direction::Up),
         'k' => Command::MoveCursor(Direction::Prev),
         'j' => Command::MoveCursor(Direction::Next),
@@ -166,7 +166,11 @@ impl<'arena, Node: Ast<'arena> + 'arena, E: EditableTree<'arena, Node> + 'arena>
     Editor<'arena, Node, E>
 {
     /// Create a new [`Editor`] with a given tree
-    pub fn new(tree: &'arena mut E, format_style: Node::FormatStyle, keymap: KeyMap) -> Editor<'arena, Node, E> {
+    pub fn new(
+        tree: &'arena mut E,
+        format_style: Node::FormatStyle,
+        keymap: KeyMap,
+    ) -> Editor<'arena, Node, E> {
         let term = Term::new().unwrap();
         Editor {
             tree,
@@ -458,7 +462,10 @@ mod tests {
             ("iX", Action::InsertChild('X')),
             ("iP", Action::InsertChild('P')),
         ] {
-            assert_eq!(parse_command(&keymap, *command), Some(expected_effect.clone()));
+            assert_eq!(
+                parse_command(&keymap, *command),
+                Some(expected_effect.clone())
+            );
         }
     }
 


### PR DESCRIPTION
Fixes the issue lotabout/tuikit#28 by showing the cursor just before exiting Sapling.