### PR TITLE
Implement cursor replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 **/*.rs.bk
+
+# File used as the piped output of Sapling (I use it for debugging)
+log

--- a/src/arena.rs
+++ b/src/arena.rs
@@ -45,3 +45,9 @@ impl<T> Arena<T> {
         &self.base_arena.alloc(Item::new(node)).node
     }
 }
+
+impl<T> Default for Arena<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/ast/json.rs
+++ b/src/ast/json.rs
@@ -254,7 +254,7 @@ impl<'arena> Ast<'arena> for JSON<'arena> {
 
     /* DEBUG VIEW FUNCTIONS */
 
-    fn children(&'arena self) -> &[&JSON<'arena>] {
+    fn children<'s>(&'s self) -> &'s [&'arena JSON<'arena>] {
         match self {
             JSON::True | JSON::False | JSON::Str(_) => &[],
             JSON::Array(children) => &children,
@@ -263,7 +263,7 @@ impl<'arena> Ast<'arena> for JSON<'arena> {
         }
     }
 
-    fn children_mut(&'arena mut self) -> &mut [&JSON<'arena>] {
+    fn children_mut<'s>(&'s mut self) -> &'s mut [&'arena JSON<'arena>] {
         match self {
             JSON::True | JSON::False | JSON::Str(_) => &mut [],
             JSON::Array(children) => children,

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -64,12 +64,12 @@ pub trait Ast<'arena>: std::fmt::Debug + Clone + Eq + Default + std::hash::Hash 
 
     /// Get a slice over the direct children of this node.  This operation is expected to be
     /// cheap - it will be used a lot of times without caching the results.
-    fn children(&'arena self) -> &[&Self];
+    fn children<'s>(&'s self) -> &'s [&'arena Self];
 
     /// Get a mutable slice over the direct children of this node.  Like
     /// [`children`](ASTSpec::children), this operation is expected to be
     /// cheap - it will be used a lot of times without caching the results.
-    fn children_mut(&'arena mut self) -> &mut [&Self];
+    fn children_mut<'s>(&'s mut self) -> &'s mut [&'arena Self];
 
     /// Get the display name of this node
     fn display_name(&self) -> String;

--- a/src/editable_tree/cursor_path.rs
+++ b/src/editable_tree/cursor_path.rs
@@ -1,0 +1,290 @@
+use crate::ast::Ast;
+
+/// A tree-independent struct for representing the locations of nodes within trees.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CursorPath {
+    child_indices: Vec<usize>,
+}
+
+impl CursorPath {
+    /// Creates a cursor path from a given [`Vec`]
+    #[inline]
+    pub fn from_vec(vec: Vec<usize>) -> CursorPath {
+        CursorPath { child_indices: vec }
+    }
+
+    /// Creates a cursor path that refers to the root of any tree.
+    #[inline]
+    pub fn root() -> CursorPath {
+        Self::from_vec(vec![])
+    }
+
+    /// Walks this path down from the given root, and returns the node that lies underneath the
+    /// cursor.
+    #[inline]
+    pub fn cursor<'arena, Node: Ast<'arena>>(&self, root: &'arena Node) -> &'arena Node {
+        // We can unwrap here because `NodeIter` is guarunteed to return at least one value
+        // (the first value it returns is always the root that we gave it).
+        self.node_iter(root).last().unwrap()
+    }
+
+    /// Walks this path down from the given root, and returns the node that lies underneath the
+    /// cursor, along with the direct parent of that node (if it exists).
+    pub fn cursor_and_parent<'arena, Node: Ast<'arena>>(
+        &self,
+        root: &'arena Node,
+    ) -> (&'arena Node, Option<&'arena Node>) {
+        // Track the current node, and the parent of that node
+        let mut node = root;
+        let mut parent: Option<&Node> = None;
+        // Step down the iterator.
+        // Invariant: At the end of every iteration, `parent` holds the parent of `node` (if that
+        //            parent exists).
+        for next_node in self.node_iter(root).skip(1) {
+            parent = Some(node);
+            node = next_node;
+        }
+        // Since `node` == `self.cursor()` and the invariant holds, this returns the cursor and its
+        // parent
+        (node, parent)
+    }
+
+    /// Pushes a new child onto the path.  This has the effect of moving the cursor one level down
+    /// the tree, to the `new_child_index`th child of the node the `CursorPath` is currently
+    /// pointing at.
+    #[inline]
+    pub fn push(&mut self, new_child_index: usize) {
+        self.child_indices.push(new_child_index);
+    }
+
+    /// Removes and returns the last child from the path (if it exists).  This has the effect of
+    /// moving the cursor to its parent, and returning the old cursor's sibling index.  Returns
+    /// `None` if the path referred to the root of the tree (and therefore the pop had no effect).
+    #[inline]
+    pub fn pop(&mut self) -> Option<usize> {
+        self.child_indices.pop()
+    }
+
+    /// Returns `true` if this path refers to the root of any tree (i.e. the path has no segments).
+    #[inline]
+    pub fn is_root(&self) -> bool {
+        self.child_indices.is_empty()
+    }
+
+    /// Returns a mutable reference to the last child index in the path (if it exists).
+    #[inline]
+    pub fn last_mut(&mut self) -> Option<&mut usize> {
+        self.child_indices.last_mut()
+    }
+
+    /// Returns an iterator over the child indices contained in this path.
+    #[inline]
+    pub fn iter(&self) -> std::slice::Iter<'_, usize> {
+        self.child_indices.iter()
+    }
+
+    /// Returns an iterator over the AST `Node`s generated when this path is traversed starting
+    /// with a given root.
+    #[inline]
+    pub fn node_iter<'arena, 'p, Node>(&'p self, root: &'arena Node) -> NodeIter<'arena, 'p, Node>
+    where
+        Node: Ast<'arena>,
+    {
+        NodeIter::new(root, &self)
+    }
+}
+
+/// An iterator that walks down a tree following a [`CursorPath`].  The first item returned from
+/// this iterator is always the root of the tree.  As a consequence, this yields one more AST node
+/// than the original tree had.
+pub struct NodeIter<'arena, 'p, Node>
+where
+    Node: Ast<'arena>,
+{
+    node: Option<&'arena Node>,
+    iter: std::slice::Iter<'p, usize>,
+}
+
+impl<'arena, 'p, Node> NodeIter<'arena, 'p, Node>
+where
+    Node: Ast<'arena>,
+{
+    /// Creates a new `NodeIter` that follows a given [`CursorPath`] down from a root `Node`.  This
+    /// will only be called from [`CursorPath::node_iter`].
+    #[inline]
+    fn new(root: &'arena Node, path: &'p CursorPath) -> Self {
+        NodeIter {
+            node: Some(root),
+            iter: path.iter(),
+        }
+    }
+
+    /// Helper function that picks the correct descendant of `self.node`, returning `None` if any
+    /// of the following conditions happen:
+    /// - the path has finished (there are no more child indices to read)
+    /// - the child index has a value too big to represent a valid child of the current node
+    /// - self.node = None; i.e. the iterator has already finished.  This condition means that this
+    ///   iterator is **fused** (see [`std::iter::Fused`])
+    #[inline]
+    fn next_descendant(&mut self) -> Option<&'arena Node> {
+        Some(*self.node?.children().get(*self.iter.next()?)?)
+    }
+}
+
+impl<'arena, 'iter, Node> Iterator for NodeIter<'arena, 'iter, Node>
+where
+    Node: Ast<'arena>,
+{
+    type Item = &'arena Node;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let last_node = self.node;
+        self.node = self.next_descendant();
+        last_node
+    }
+}
+
+// Because of how [`NodeIter::next_descendant`] works, NodeIter is a fused iterator - it will
+// never return Some(x) after the first None.
+impl<'arena, Node: Ast<'arena>> std::iter::FusedIterator for NodeIter<'arena, '_, Node> {}
+
+#[cfg(test)]
+mod tests {
+    use super::CursorPath;
+    use crate::arena::Arena;
+    use crate::ast::{json::JSON, test_json::TestJSON, Ast};
+
+    #[test]
+    fn is_root() {
+        // A path that's created as a root is ... a root!
+        let mut path = CursorPath::root();
+        assert!(path.is_root());
+        // Moving to any child stops it being a root
+        path.push(0);
+        assert!(!path.is_root());
+        // Pushing more children means it still isn't a root
+        path.push(4);
+        assert!(!path.is_root());
+        // If we pop *one* child, we're still not back at the root
+        assert_eq!(path.pop(), Some(4));
+        assert!(!path.is_root());
+        // But if we pop the last child, we get back to the root
+        assert_eq!(path.pop(), Some(0));
+        assert!(path.is_root());
+    }
+
+    #[test]
+    fn node_iter() {
+        // Create some test JSON and add it to an arena
+        let arena = Arena::new();
+        let root = TestJSON::Array(vec![
+            TestJSON::True,
+            TestJSON::False,
+            TestJSON::Object(vec![("value".to_string(), TestJSON::True)]),
+        ])
+        .add_to_arena(&arena);
+        // Create a path to the root, and test properties of it
+        let mut path = CursorPath::root();
+        assert_eq!(path.node_iter(root).collect::<Vec<&JSON<'_>>>(), [root]);
+        // Move the path to the 2nd ('1th') child (which is 'false')
+        path.push(1);
+        assert_eq!(
+            path.node_iter(root)
+                .map(|x| x.display_name())
+                .collect::<Vec<_>>(),
+            vec!["array".to_string(), "false".to_string()]
+        );
+        // Move to the ':' field object
+        *path.last_mut().unwrap() = 2;
+        path.push(0);
+        assert_eq!(
+            path.node_iter(root)
+                .map(|x| x.display_name())
+                .collect::<Vec<_>>(),
+            vec![
+                "array".to_string(),
+                "object".to_string(),
+                "field".to_string()
+            ]
+        );
+        // Move down to the 'true' in the object
+        path.push(1);
+        assert_eq!(
+            path.node_iter(root)
+                .map(|x| x.display_name())
+                .collect::<Vec<_>>(),
+            vec![
+                "array".to_string(),
+                "object".to_string(),
+                "field".to_string(),
+                "true".to_string()
+            ]
+        );
+        // Pop back up two levels to the object
+        assert_eq!(path.pop(), Some(1));
+        assert_eq!(path.pop(), Some(0));
+        assert_eq!(
+            path.node_iter(root)
+                .map(|x| x.display_name())
+                .collect::<Vec<_>>(),
+            vec!["array".to_string(), "object".to_string(),]
+        );
+    }
+
+    #[test]
+    fn cursor() {
+        // Create some test JSON and add it to an arena
+        let arena = Arena::new();
+        let root = TestJSON::Array(vec![
+            TestJSON::True,
+            TestJSON::False,
+            TestJSON::Object(vec![("value".to_string(), TestJSON::True)]),
+        ])
+        .add_to_arena(&arena);
+        // Create a path to the root, and check that the cursor is the root
+        let mut path = CursorPath::root();
+        assert!(std::ptr::eq(path.cursor(root), root));
+        // Move down to the 'false' object
+        path.push(1);
+        assert_eq!(path.cursor(root).display_name(), "false");
+        // Move to the ':' field object
+        *path.last_mut().unwrap() = 2;
+        path.push(0);
+        assert_eq!(path.cursor(root).display_name(), "field");
+        // Move down to the 'true' in the object
+        path.push(1);
+        assert_eq!(path.cursor(root).display_name(), "true");
+    }
+
+    #[test]
+    fn cursor_and_parent() {
+        // Create some test JSON and add it to an arena
+        let arena = Arena::new();
+        let root = TestJSON::Array(vec![
+            TestJSON::True,
+            TestJSON::False,
+            TestJSON::Object(vec![("value".to_string(), TestJSON::True)]),
+        ])
+        .add_to_arena(&arena);
+        // Create a path to the root.  The root has no parent
+        let mut path = CursorPath::root();
+        assert_eq!(path.cursor_and_parent(root), (root, None));
+        // Move down to the 'false' object.  Now the parent is the root
+        path.push(1);
+        let (c, p) = path.cursor_and_parent(root);
+        assert_eq!(c.display_name(), "false");
+        assert!(std::ptr::eq(p.unwrap(), root));
+        // Move to the ':' field object, whos parent is an 'object'
+        *path.last_mut().unwrap() = 2;
+        path.push(0);
+        let (c, p) = path.cursor_and_parent(root);
+        assert_eq!(c.display_name(), "field");
+        assert_eq!(p.unwrap().display_name(), "object");
+        // Move down to the 'true' in the object
+        path.push(1);
+        let (c, p) = path.cursor_and_parent(root);
+        assert_eq!(c.display_name(), "true");
+        assert_eq!(p.unwrap().display_name(), "field");
+    }
+}

--- a/src/editable_tree/dag.rs
+++ b/src/editable_tree/dag.rs
@@ -73,7 +73,7 @@ impl<'arena, Node: Ast<'arena>> EditableTree<'arena, Node> for DAG<'arena, Node>
     /* NAVIGATION METHODS */
 
     fn root(&self) -> &'arena Node {
-        // This indexing cannot panic because we require that `self.history_index` is a valid index
+        // This indexing shouldn't panic because we require that `self.history_index` is a valid index
         // into `self.root_history`, and `self.root_history` has at least one element
         self.root_history[self.history_index].0
     }
@@ -116,7 +116,7 @@ impl<'arena, Node: Ast<'arena>> EditableTree<'arena, Node> for DAG<'arena, Node>
                 if let Some(last_index) = self.current_cursor_path.last_mut() {
                     // We can unwrap here, because the only way for a node to not have a parent is
                     // if it's the root.  And if the cursor is at the root, then the `if let` would
-                    // fail, so this code would not run.
+                    // have failed and this code would not be run.
                     if *last_index + 1 < cursor_parent.unwrap().children().len() {
                         *last_index += 1;
                         None

--- a/src/editable_tree/dag.rs
+++ b/src/editable_tree/dag.rs
@@ -47,6 +47,10 @@ impl<'arena, Node: Ast<'arena>> EditableTree<'arena, Node> for DAG<'arena, Node>
     fn undo(&mut self) -> bool {
         if self.history_index > 0 {
             self.history_index -= 1;
+            // Follow the behaviour of other text editors and update the location of the cursor
+            // with its location in the snapshot we are going back to
+            self.current_cursor_path
+                .clone_from(&self.root_history[self.history_index].1);
             true
         } else {
             false
@@ -56,6 +60,10 @@ impl<'arena, Node: Ast<'arena>> EditableTree<'arena, Node> for DAG<'arena, Node>
     fn redo(&mut self) -> bool {
         if self.history_index < self.root_history.len() - 1 {
             self.history_index += 1;
+            // Follow the behaviour of other text editors and update the location of the cursor
+            // with its location in the snapshot we are going back to
+            self.current_cursor_path
+                .clone_from(&self.root_history[self.history_index].1);
             true
         } else {
             false

--- a/src/editable_tree/dag.rs
+++ b/src/editable_tree/dag.rs
@@ -101,7 +101,7 @@ impl<'arena, Node: Ast<'arena>> EditableTree<'arena, Node> for DAG<'arena, Node>
                         None
                     }
                 } else {
-                    return Some("Cannot move to a sibling of the root.".to_string());
+                    Some("Cannot move to a sibling of the root.".to_string())
                 }
             }
             Direction::Next => {
@@ -116,7 +116,7 @@ impl<'arena, Node: Ast<'arena>> EditableTree<'arena, Node> for DAG<'arena, Node>
                         Some("Cannot move past the last sibling of a node.".to_string())
                     }
                 } else {
-                    return Some("Cannot move to a sibling of the root.".to_string());
+                    Some("Cannot move to a sibling of the root.".to_string())
                 }
             }
         }

--- a/src/editable_tree/mod.rs
+++ b/src/editable_tree/mod.rs
@@ -1,5 +1,6 @@
 //! Specification of an editable, undoable buffer of trees and some implementations thereof.
 
+pub mod cursor_path;
 pub mod dag;
 
 use crate::arena::Arena;


### PR DESCRIPTION
After this PR, pressing `r` will replace the node underneath the cursor, not always the root of the tree.  Also, `undo`/`redo` will save the location of the cursor (like vim does).