### PR TITLE
Allow user to insert nodes on either side of the cursor with `i` and `a`

### DIFF
--- a/src/editable_tree/dag.rs
+++ b/src/editable_tree/dag.rs
@@ -1,5 +1,5 @@
 use super::cursor_path::CursorPath;
-use super::{Direction, EditableTree};
+use super::{Direction, EditableTree, Side};
 use crate::arena::Arena;
 use crate::ast::Ast;
 
@@ -174,6 +174,42 @@ impl<'arena, Node: Ast<'arena>> EditableTree<'arena, Node> for DAG<'arena, Node>
         // clone, so we pop that reference.
         assert!(nodes_to_clone.pop().is_some());
         self.finish_edit(&nodes_to_clone, new_node);
+    }
+
+    fn insert_next_to_cursor(
+        &mut self,
+        new_node: Node,
+        side: Side,
+    ) -> Result<(), Self::InsertError> {
+        // Generate a vec of pointers to the nodes that we will have to clone.  We have to store
+        // this as a vec because the iterator that produces them (cursor_path::NodeIter) can only
+        // yield values from the root downwards, whereas we need the nodes in the opposite order.
+        let mut nodes_to_clone: Vec<_> = self.current_cursor_path.node_iter(self.root()).collect();
+        // Pop the cursor, because it will be unchanged.  The only part of this that we need is
+        // the cursor's index.
+        assert!(nodes_to_clone.pop().is_some());
+        if nodes_to_clone.is_empty() {
+            // TODO: Return an error
+            log::warn!("Trying to add a sibling to the root!");
+            panic!();
+        }
+        // Find the index of the cursor, so that we know where to insert.  We can unwrap, because
+        // if we were at the root, then we'd early return from the if statement above
+        let cursor_sibling_index = *self.current_cursor_path.last_mut().unwrap();
+        let insert_index = cursor_sibling_index
+            + match side {
+                Side::Prev => 0,
+                Side::Next => 1,
+            };
+        let new_child_node = self.arena.alloc(new_node);
+        // Clone the node that currently is the cursor, and add the new child to the end of its
+        // children.  Unwrapping here is fine, because `cursor_path::NodeIter` will always
+        // return one value.
+        let mut cloned_parent = nodes_to_clone.pop().unwrap().clone();
+        // Add the new child to the children of the cloned cursor
+        cloned_parent.insert_child(new_child_node, insert_index)?;
+        self.finish_edit(&nodes_to_clone, cloned_parent);
+        Ok(())
     }
 
     fn insert_child(&mut self, new_node: Node) -> Result<(), Self::InsertError> {

--- a/src/editable_tree/dag.rs
+++ b/src/editable_tree/dag.rs
@@ -26,11 +26,6 @@ pub struct DAG<'arena, Node: Ast<'arena>> {
 }
 
 impl<'arena, Node: Ast<'arena>> DAG<'arena, Node> {
-    /// Returns the cursor node and its direct parent (if such a parent exists)
-    fn cursor_and_parent(&self) -> (&'arena Node, Option<&'arena Node>) {
-        self.current_cursor_path.cursor_and_parent(self.root())
-    }
-
     /// Utility function to finish an edit.  This handles removing any redo history, and cloning
     /// the nodes that are parents of the node that changed.
     fn finish_edit(&mut self, nodes_to_clone: &[&'arena Node], new_node: Node) {
@@ -112,6 +107,10 @@ impl<'arena, Node: Ast<'arena>> EditableTree<'arena, Node> for DAG<'arena, Node>
         // This indexing shouldn't panic because we require that `self.history_index` is a valid index
         // into `self.root_history`, and `self.root_history` has at least one element
         self.root_history[self.history_index].0
+    }
+
+    fn cursor_and_parent(&self) -> (&'arena Node, Option<&'arena Node>) {
+        self.current_cursor_path.cursor_and_parent(self.root())
     }
 
     fn cursor(&self) -> &'arena Node {

--- a/src/editable_tree/mod.rs
+++ b/src/editable_tree/mod.rs
@@ -16,6 +16,13 @@ pub enum Direction {
     Next,
 }
 
+/// An enum to represent the two sides of a cursor
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum Side {
+    Prev,
+    Next,
+}
+
 /// A trait specifying an editable, undoable buffer of trees
 pub trait EditableTree<'arena, Node: Ast<'arena>>: Sized {
     type InsertError: Error;
@@ -58,6 +65,14 @@ pub trait EditableTree<'arena, Node: Ast<'arena>>: Sized {
     /// Updates the internal state so that the tree now contains `new_node` inserted as the first
     /// child of the selected node.  Also moves the cursor so that the new node is selected.
     fn insert_child(&mut self, new_node: Node) -> Result<(), Self::InsertError>;
+
+    /// Updates the internal state so that the tree now contains `new_node` inserted as the first
+    /// child of the selected node.  Also moves the cursor so that the new node is selected.
+    fn insert_next_to_cursor(
+        &mut self,
+        new_node: Node,
+        side: Side,
+    ) -> Result<(), Self::InsertError>;
 
     /* DISPLAY METHODS */
 

--- a/src/editable_tree/mod.rs
+++ b/src/editable_tree/mod.rs
@@ -39,6 +39,9 @@ pub trait EditableTree<'arena, Node: Ast<'arena>>: Sized {
     /// Returns a reference to the node that is currently the root of the AST.
     fn root(&self) -> &'arena Node;
 
+    /// Returns the cursor node and its direct parent (if such a parent exists)
+    fn cursor_and_parent(&self) -> (&'arena Node, Option<&'arena Node>);
+
     /// Returns a reference to the node that is currently under the cursor.
     fn cursor(&self) -> &'arena Node;
 


### PR DESCRIPTION
Fixes #9.