### PR TITLE
Make parse_command more idiomatic

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -267,52 +267,32 @@ fn parse_command(keymap: &KeyMap, command: &str) -> Option<Action> {
     let mut command_char_iter = command.chars();
 
     // Consume the first char of the command
-    if let Some(c) = command_char_iter.next() {
-        match keymap.get(&c) {
-            // "q" quits Sapling
-            Some(Command::Quit) => {
-                return Some(Action::Quit);
-            }
-            Some(Command::InsertChild) => {
-                // Consume the second char of the iterator
-                if let Some(insert_char) = command_char_iter.next() {
-                    return Some(Action::InsertChild(insert_char));
-                }
-            }
-            Some(Command::InsertBefore) => {
-                // Consume the second char of the iterator
-                if let Some(insert_char) = command_char_iter.next() {
-                    return Some(Action::InsertBefore(insert_char));
-                }
-            }
-            Some(Command::InsertAfter) => {
-                // Consume the second char of the iterator
-                if let Some(insert_char) = command_char_iter.next() {
-                    return Some(Action::InsertAfter(insert_char));
-                }
-            }
-            Some(Command::Replace) => {
-                // Consume the second char of the iterator
-                if let Some(replace_char) = command_char_iter.next() {
-                    return Some(Action::Replace(replace_char));
-                }
-            }
-            Some(Command::MoveCursor(direction)) => {
-                return Some(Action::MoveCursor(*direction));
-            }
-            Some(Command::Undo) => {
-                return Some(Action::Undo);
-            }
-            Some(Command::Redo) => {
-                return Some(Action::Redo);
-            }
-            None => {
-                return Some(Action::Undefined);
-            }
-        }
-    }
+    let c = command_char_iter.next()?;
 
-    None
+    match keymap.get(&c) {
+        // "q" quits Sapling
+        Some(Command::Quit) => Some(Action::Quit),
+        Some(Command::InsertChild) => {
+            // Consume the second char of the iterator
+            command_char_iter.next().map(Action::InsertChild)
+        }
+        Some(Command::InsertBefore) => {
+            // Consume the second char of the iterator
+            command_char_iter.next().map(Action::InsertBefore)
+        }
+        Some(Command::InsertAfter) => {
+            // Consume the second char of the iterator
+            command_char_iter.next().map(Action::InsertAfter)
+        }
+        Some(Command::Replace) => {
+            // Consume the second char of the iterator
+            command_char_iter.next().map(Action::Replace)
+        }
+        Some(Command::MoveCursor(direction)) => Some(Action::MoveCursor(*direction)),
+        Some(Command::Undo) => Some(Action::Undo),
+        Some(Command::Redo) => Some(Action::Redo),
+        None => Some(Action::Undefined),
+    }
 }
 
 /// A struct to hold the top-level components of the editor.


### PR DESCRIPTION
This refactors `parse_command` a bit to make it more idiomatic. The
changes are:

* Use of `?` to decrease nesting
* Removed `return`s
* Change `if let Some(foo) = bar { Some(baz) }` to `.map()` combinator
* Remove `{}` in `match` arms as those expressions are trivial (rustfmt)

(Noticed this during stream but it felt off-topic, so I made a PR now instead.)