### PR TITLE
Implement deletion of nodes

### DIFF
--- a/src/ast/json.rs
+++ b/src/ast/json.rs
@@ -47,6 +47,50 @@ impl std::fmt::Display for InsertError {
 
 impl std::error::Error for InsertError {}
 
+/// Error produced when trying to delete a child from this node
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub enum DeleteError {
+    /// We attempted to delete a child who's index was outside the bounds of the child array
+    IndexOutOfRange(usize, usize),
+    /// We attempted to delete a child from a node which must contain a fixed number of children
+    FixedChildCount(String, usize),
+}
+
+impl std::fmt::Display for DeleteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeleteError::IndexOutOfRange(num_children, index) => write!(
+                f,
+                "Tried to remove child #{} from a node that only has {} children.",
+                index, num_children
+            ),
+            DeleteError::FixedChildCount(node, num_children) => {
+                if *num_children == 0 {
+                    write!(
+                        f,
+                        "Node {} cannot have children, but we tried to delete a child.",
+                        node
+                    )
+                } else if *num_children == 1 {
+                    write!(
+                        f,
+                        "Cannot delete from a node {} that can only have 1 child.",
+                        node
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Cannot delete from a node {} that can only have {} children.",
+                        node, num_children
+                    )
+                }
+            }
+        }
+    }
+}
+
+impl std::error::Error for DeleteError {}
+
 /// The sapling representation of the AST for a subset of JSON (where all values are either 'true'
 /// or 'false', and keys only contain ASCII).
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
@@ -99,6 +143,7 @@ impl Default for JSON<'_> {
 impl<'arena> Ast<'arena> for JSON<'arena> {
     type FormatStyle = JSONFormat;
     type InsertError = InsertError;
+    type DeleteError = DeleteError;
 
     /* FORMATTING FUNCTIONS */
 
@@ -326,6 +371,31 @@ impl<'arena> Ast<'arena> for JSON<'arena> {
             JSON::Array(children) => {
                 children.insert(index, new_node);
                 Ok(())
+            }
+        }
+    }
+
+    fn delete_child(&mut self, index: usize) -> Result<(), Self::DeleteError> {
+        match self {
+            JSON::True | JSON::False | JSON::Null | JSON::Str(_) => {
+                Err(DeleteError::FixedChildCount(self.display_name(), 0))
+            }
+            JSON::Field(_) => Err(DeleteError::FixedChildCount(self.display_name(), 2)),
+            JSON::Object(fields) => {
+                if index < fields.len() {
+                    fields.remove(index);
+                    Ok(())
+                } else {
+                    Err(DeleteError::IndexOutOfRange(fields.len(), index))
+                }
+            }
+            JSON::Array(children) => {
+                if index < children.len() {
+                    children.remove(index);
+                    Ok(())
+                } else {
+                    Err(DeleteError::IndexOutOfRange(children.len(), index))
+                }
             }
         }
     }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -12,7 +12,10 @@ use size::Size;
 pub trait Ast<'arena>: std::fmt::Debug + Clone + Eq + Default + std::hash::Hash {
     /// A type parameter that will represent the different ways this AST can be rendered
     type FormatStyle;
+    /// Error type returned by [Ast::insert_child].
     type InsertError: std::error::Error;
+    /// Error type returned by [Ast::delete_child].
+    type DeleteError: std::error::Error;
 
     /* FORMATTING FUNCTIONS */
 
@@ -67,6 +70,10 @@ pub trait Ast<'arena>: std::fmt::Debug + Clone + Eq + Default + std::hash::Hash 
     /// [`children`](ASTSpec::children), this operation is expected to be
     /// cheap - it will be used a lot of times without caching the results.
     fn children_mut<'s>(&'s mut self) -> &'s mut [&'arena Self];
+
+    /// Removes the child at a given index from the children of this node, if possible.  If the
+    /// removal was not possible, then we return a custom error type.
+    fn delete_child(&mut self, index: usize) -> Result<(), Self::DeleteError>;
 
     /// Insert an extra child into the children of this node at a given index.
     fn insert_child(

--- a/src/editable_tree/mod.rs
+++ b/src/editable_tree/mod.rs
@@ -159,7 +159,7 @@ impl<'arena, Node: Ast<'arena>> DAG<'arena, Node> {
 
     /// Utility function to finish an edit.  This handles removing any redo history, and cloning
     /// the nodes that are parents of the node that changed.
-    pub fn finish_edit(&mut self, nodes_to_clone: &[&'arena Node], new_node: Node) {
+    fn finish_edit(&mut self, nodes_to_clone: &[&'arena Node], new_node: Node) {
         // Remove future trees from the history vector so that the currently 'checked-out' tree is
         // the most recent tree in the history.
         while self.history_index < self.root_history.len() - 1 {


### PR DESCRIPTION
Pressing `d` will delete the node currently under the cursor.  Since Sapling currently has neither multiple cursors nor any concept of selections, I think this will be a decent placeholder.