### PR TITLE
 Small key binding changes #38 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,14 @@ cargo run
 
 #### Cursor Movement
 
-- `j`/`k`: Move the cursor up and down (respectively) by one child
+- `h`/`k`: Move the cursor to the previous sibling of the current node
+- `j`/`l`: Move the cursor to the next sibling of the current node
 - `c`: Move the cursor to the first child of the current node (if it exists)
 - `p`: Move the cursor to the parent of the node it's currently at
 
 #### Modify the tree
 - `r*`: Replace the node under the cursor with the node represented by the key `*`
-- `d`: Delete the node under the cursor (will probably be remapped to `x`)
+- `x`: Delete the node under the cursor (will probably be remapped to `x`)
 - `o*`: Insert a new node represented by `*` as a **child** of the cursor
 - `a*`/`i*`: Insert a new node represented by `*` before or after the cursor respectively
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -194,11 +194,13 @@ pub fn default_keymap() -> KeyMap {
         'a' => Command::InsertAfter,
         'o' => Command::InsertChild,
         'r' => Command::Replace,
-        'd' => Command::Delete,
+        'x' => Command::Delete,
         'c' => Command::MoveCursor(Direction::Down),
         'p' => Command::MoveCursor(Direction::Up),
-        'k' => Command::MoveCursor(Direction::Prev),
+        'h' => Command::MoveCursor(Direction::Prev),
         'j' => Command::MoveCursor(Direction::Next),
+        'k' => Command::MoveCursor(Direction::Prev),
+        'l' => Command::MoveCursor(Direction::Next),
         'u' => Command::Undo,
         'R' => Command::Redo
     }
@@ -664,7 +666,12 @@ mod tests {
         let keymap = super::default_keymap();
         for (command, expected_effect) in &[
             ("q", Action::Quit),
-            ("x", Action::Undefined),
+            ("x", Action::Delete),
+            ("d", Action::Undefined),
+            ("h", Action::MoveCursor(Direction::Prev)),
+            ("j", Action::MoveCursor(Direction::Next)),
+            ("k", Action::MoveCursor(Direction::Prev)),
+            ("l", Action::MoveCursor(Direction::Next)),
             ("pajlbsi", Action::MoveCursor(Direction::Up)),
             ("Pxx", Action::Undefined),
             ("Qsx", Action::Undefined),


### PR DESCRIPTION
remapped 'x' to delete, 'h' 'l' to previous and next sibling of current node
fixed issue #38 

resolves #35 and resolves #33.