### PR TITLE
Add explicit categories for actions

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -71,7 +71,7 @@ mod command_log {
                 .iter()
                 .map(|e| match e.count {
                     1 => 0,
-                    c => format!("{}", c).len(),
+                    c => format!("{}x", c).len(),
                 })
                 .max()
                 .unwrap_or(0)


### PR DESCRIPTION
This was mainly to split up `Action::description_and_color` in such a way that `Action` doesn't depend on the exact terminal backend.

@stokhos: this needs to be merged so that the changes can be refactored when fixing #32, so I'll merge it right away.