### PR TITLE
replaced is_insert_char and is_replace_char with is_valid_child fixes #37 

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,12 @@ play around with Sapling as it currently stands, the best way is to clone the re
 from source (you'll need [Rust](https://www.rust-lang.org/learn/get-started) installed in order to do this):
 ```bash
 git clone https://github.com/kneasle/sapling.git
-cargo run
+cargo run 2> log
 ```
+
+Note that Sapling will not compile for Windows.  Windows support is absolutely intended, but Sapling currently uses
+[tuikit](https://github.com/lotabout/tuikit) as a terminal abstraction, which does not yet have Windows support.  PRs to
+Sapling or `tuikit` to add support for Windows would be very much appreciated.
 
 ### Current Keybindings
 

--- a/src/ast/json.rs
+++ b/src/ast/json.rs
@@ -21,6 +21,7 @@ const CHAR_NULL: char = 'n';
 const CHAR_ARRAY: char = 'a';
 const CHAR_OBJECT: char = 'o';
 const CHAR_STRING: char = 's';
+const CHAR_FIELD: char = 'e';
 
 /// The sapling representation of the AST for a subset of JSON (where all values are either 'true'
 /// or 'false', and keys only contain ASCII).
@@ -58,6 +59,7 @@ impl JSON<'_> {
                 CHAR_ARRAY,
                 CHAR_OBJECT,
                 CHAR_STRING,
+                CHAR_FIELD,
             ]
             .iter()
             .copied(),
@@ -392,12 +394,25 @@ impl<'arena> Ast<'arena> for JSON<'arena> {
         }
     }
 
-    fn insert_chars(&self) -> Box<dyn Iterator<Item = char>> {
+    fn holds_child(&self) -> bool {
         match self {
-            JSON::True | JSON::False | JSON::Null | JSON::Field(_) | JSON::Str(_) => {
-                Box::new(std::iter::empty())
-            }
-            JSON::Object(_) | JSON::Array(_) => Self::all_object_chars(),
+            JSON::True | JSON::False | JSON::Null | JSON::Str(_) => false,
+            JSON::Object(_) | JSON::Array(_) | JSON::Field(_) => true,
+        }
+    }
+
+    fn valid_chars(&self) -> Box<dyn Iterator<Item = char>> {
+        Self::all_object_chars()
+    }
+
+    fn valid_key_chars(&self) -> Box<dyn Iterator<Item = char>> {
+        Box::new([CHAR_STRING].iter().copied())
+    }
+
+    fn holds_paired_child(&self) -> bool {
+        match self {
+            JSON::Field(_) => true,
+            _ => false,
         }
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -206,8 +206,8 @@ pub trait Ast<'arena>: std::fmt::Debug + Clone + Eq + Default + std::hash::Hash 
     /* AST EDITING FUNCTIONS */
 
     /// Generate a new node from a [`char`] that a user typed.  If `c` is an element of
-    /// [`valid_chars`](Ast::valid_chars), at current cursor position, [is_valid_child](Ast::is_valid_child) or [is_valid_root](Ast::is_valid_root) they must return [`true`],
-    /// if it isn't, then this should return [`false`].
+    /// [`valid_chars`](Ast::valid_chars), this must return [`Some`],
+    /// if it isn't, then this should return [`None`].
     fn from_char(&self, c: char) -> Option<Self>;
 
     /// Generate an iterator over the possible shorthand [`char`]s for valid  node

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -205,49 +205,17 @@ pub trait Ast<'arena>: std::fmt::Debug + Clone + Eq + Default + std::hash::Hash 
 
     /* AST EDITING FUNCTIONS */
 
-    /// Generate an iterator over the possible shorthand [`char`]s that a user could type to replace
-    /// this node with something else.
-    fn replace_chars(&self) -> Box<dyn Iterator<Item = char>>;
-
-    /// Returns whether or not a given [`char`] is in [`Self::replace_chars`]
-    fn is_replace_char(&self, c: char) -> bool {
-        self.replace_chars().any(|x| x == c)
-    }
-
     /// Generate a new node from a [`char`] that a user typed.  If `c` is an element of
     /// [`get_replace_chars`](Ast::replace_chars), this must return [`Some`] node,
     /// if it isn't, then this should return [`None`].
     fn from_char(&self, c: char) -> Option<Self>;
 
     /// Generate an iterator over the possible shorthand [`char`]s for valid  node
-    fn valid_chars(&self) -> Box<dyn Iterator<Item = char>>;
-
-    /// Generate an iterator over the possible shorthand [`char`]s that a user could use as a key
-    /// in node that hold key-value pairs
-    fn valid_key_chars(&self) -> Box<dyn Iterator<Item = char>>;
-
-    /// Returns whether or not the current node can have child in key-value form
-    fn holds_paired_child(&self) -> bool;
-
-    /// Returns whether or not the current node can have child in key-value form
-    fn holds_child(&self) -> bool;
+    fn valid_chars() -> Box<dyn Iterator<Item = char>>;
 
     /// Returns whether or not a given index and [`char`] is a valid child
-    fn is_valid_child(&self, index: usize, c: char) -> bool {
-        if self.holds_paired_child() {
-            match index {
-                0 => self.valid_key_chars().any(|x| x == c),
-                _ => self.valid_chars().any(|x| x == c),
-            }
-        } else if self.holds_child() {
-            self.valid_chars().any(|x| x == c)
-        } else {
-            false
-        }
-    }
+    fn is_valid_child(&self, index: usize, c: char) -> bool;
 
     /// Returns whether or not a give index and ['char'] is a valid root
-    fn is_valid_root(&self, c: char) -> bool {
-        self.valid_chars().any(|x| x == c)
-    }
+    fn is_valid_root(&self, c: char) -> bool;
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -206,8 +206,8 @@ pub trait Ast<'arena>: std::fmt::Debug + Clone + Eq + Default + std::hash::Hash 
     /* AST EDITING FUNCTIONS */
 
     /// Generate a new node from a [`char`] that a user typed.  If `c` is an element of
-    /// [`get_replace_chars`](Ast::replace_chars), this must return [`Some`] node,
-    /// if it isn't, then this should return [`None`].
+    /// [`valid_chars`](Ast::valid_chars), at current cursor position, [is_valid_child](Ast::is_valid_child) or [is_valid_root](Ast::is_valid_root) they must return [`true`],
+    /// if it isn't, then this should return [`false`].
     fn from_char(&self, c: char) -> Option<Self>;
 
     /// Generate an iterator over the possible shorthand [`char`]s for valid  node

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -219,12 +219,35 @@ pub trait Ast<'arena>: std::fmt::Debug + Clone + Eq + Default + std::hash::Hash 
     /// if it isn't, then this should return [`None`].
     fn from_char(&self, c: char) -> Option<Self>;
 
-    /// Generate an iterator over the possible shorthand [`char`]s that a user could type to insert
-    /// other nodes into this one
-    fn insert_chars(&self) -> Box<dyn Iterator<Item = char>>;
+    /// Generate an iterator over the possible shorthand [`char`]s for valid  node
+    fn valid_chars(&self) -> Box<dyn Iterator<Item = char>>;
 
-    /// Returns whether or not a given [`char`] is in [`Self::insert_chars`]
-    fn is_insert_char(&self, c: char) -> bool {
-        self.insert_chars().any(|x| x == c)
+    /// Generate an iterator over the possible shorthand [`char`]s that a user could use as a key
+    /// in node that hold key-value pairs
+    fn valid_key_chars(&self) -> Box<dyn Iterator<Item = char>>;
+
+    /// Returns whether or not the current node can have child in key-value form
+    fn holds_paired_child(&self) -> bool;
+
+    /// Returns whether or not the current node can have child in key-value form
+    fn holds_child(&self) -> bool;
+
+    /// Returns whether or not a given index and [`char`] is a valid child
+    fn is_valid_child(&self, index: usize, c: char) -> bool {
+        if self.holds_paired_child() {
+            match index {
+                0 => self.valid_key_chars().any(|x| x == c),
+                _ => self.valid_chars().any(|x| x == c),
+            }
+        } else if self.holds_child() {
+            self.valid_chars().any(|x| x == c)
+        } else {
+            false
+        }
+    }
+
+    /// Returns whether or not a give index and ['char'] is a valid root
+    fn is_valid_root(&self, c: char) -> bool {
+        self.valid_chars().any(|x| x == c)
     }
 }

--- a/src/core/path.rs
+++ b/src/core/path.rs
@@ -78,7 +78,7 @@ impl Path {
         self.child_indices.is_empty()
     }
 
-    /// Returns a mutable reference to the last child index in the path (if it exists).
+    /// Returns the last child index in the path (if it exists).
     #[inline]
     pub fn last(&self) -> Option<usize> {
         self.child_indices.last().copied()

--- a/src/editor/dag.rs
+++ b/src/editor/dag.rs
@@ -382,37 +382,24 @@ impl<'arena, Node: Ast<'arena>> DAG<'arena, Node> {
                                     .map_or("<root>".to_string(), |(p, _)| p.display_name()),
                             });
                         }
-
-                        let new_node = cursor.from_char(c).ok_or(EditErr::CharNotANode(c))?;
-
-                        let new_node_name = new_node.display_name();
-                        Ok((
-                            new_node,
-                            EditLocation::Cursor,
-                            EditSuccess::Replace {
-                                c,
-                                name: new_node_name,
-                            },
-                        ))
                     }
                     None => {
                         if !cursor.is_valid_root(c) {
                             return Err(EditErr::CharNotANode(c));
                         }
-
-                        let new_node = cursor.from_char(c).ok_or(EditErr::CharNotANode(c))?;
-
-                        let new_node_name = new_node.display_name();
-                        Ok((
-                            new_node,
-                            EditLocation::Cursor,
-                            EditSuccess::Replace {
-                                c,
-                                name: new_node_name,
-                            },
-                        ))
                     }
                 }
+                let new_node = cursor.from_char(c).ok_or(EditErr::CharNotANode(c))?;
+
+                let new_node_name = new_node.display_name();
+                Ok((
+                    new_node,
+                    EditLocation::Cursor,
+                    EditSuccess::Replace {
+                        c,
+                        name: new_node_name,
+                    },
+                ))
             },
         )
     }
@@ -433,70 +420,38 @@ impl<'arena, Node: Ast<'arena>> DAG<'arena, Node> {
                                 parent_name: cursor.display_name(),
                             });
                         }
-
-                        // Create the node to insert
-                        let new_node = this
-                            .arena
-                            .alloc(cursor.from_char(c).ok_or(EditErr::CharNotANode(c))?);
-                        let new_node_name = new_node.display_name();
-                        // Clone the node that currently is the cursor, and add the new child to the end of its
-                        // children.
-                        let mut cloned_cursor = cursor.clone();
-                        // Store the new_node's display name before it's consumed by `finish_edit`
-                        // Add the new child to the children of the cloned cursor
-                        cloned_cursor.insert_child(
-                            new_node,
-                            this.arena,
-                            cloned_cursor.children().len(),
-                        )?;
-
-                        // moves the cursor to the newly added child
-                        this.current_cursor_path.push(cursor.children().len());
-
-                        Ok((
-                            cloned_cursor,
-                            EditLocation::Cursor,
-                            EditSuccess::InsertChild {
-                                c,
-                                name: new_node_name,
-                            },
-                        ))
                     }
                     None => {
                         // Short circuit if `c` couldn't be a valid child of the cursor
                         if !cursor.is_valid_root(c) {
                             return Err(EditErr::CharNotANode(c));
                         }
-
-                        // Create the node to insert
-                        let new_node = this
-                            .arena
-                            .alloc(cursor.from_char(c).ok_or(EditErr::CharNotANode(c))?);
-                        let new_node_name = new_node.display_name();
-                        // Clone the node that currently is the cursor, and add the new child to the end of its
-                        // children.
-                        let mut cloned_cursor = cursor.clone();
-                        // Store the new_node's display name before it's consumed by `finish_edit`
-                        // Add the new child to the children of the cloned cursor
-                        cloned_cursor.insert_child(
-                            new_node,
-                            this.arena,
-                            cloned_cursor.children().len(),
-                        )?;
-
-                        // moves the cursor to the newly added child
-                        this.current_cursor_path.push(cursor.children().len());
-
-                        Ok((
-                            cloned_cursor,
-                            EditLocation::Cursor,
-                            EditSuccess::InsertChild {
-                                c,
-                                name: new_node_name,
-                            },
-                        ))
                     }
                 }
+
+                // Create the node to insert
+                let new_node = this
+                    .arena
+                    .alloc(cursor.from_char(c).ok_or(EditErr::CharNotANode(c))?);
+                let new_node_name = new_node.display_name();
+                // Clone the node that currently is the cursor, and add the new child to the end of its
+                // children.
+                let mut cloned_cursor = cursor.clone();
+                // Store the new_node's display name before it's consumed by `finish_edit`
+                // Add the new child to the children of the cloned cursor
+                cloned_cursor.insert_child(new_node, this.arena, cloned_cursor.children().len())?;
+
+                // moves the cursor to the newly added child
+                this.current_cursor_path.push(cursor.children().len());
+
+                Ok((
+                    cloned_cursor,
+                    EditLocation::Cursor,
+                    EditSuccess::InsertChild {
+                        c,
+                        name: new_node_name,
+                    },
+                ))
             },
         )
     }

--- a/src/editor/dag.rs
+++ b/src/editor/dag.rs
@@ -1299,7 +1299,6 @@ mod tests {
 
     #[test]
     fn level_1_replace() {
-        /*
         run_test_ok(
             TestJSON::Array(vec![TestJSON::True, TestJSON::Array(vec![])]),
             Path::from_vec(vec![1]),
@@ -1356,7 +1355,7 @@ mod tests {
             TestJSON::Array(vec![
                 TestJSON::True,
                 TestJSON::Object(vec![
-                    ("key-1".to_string(), TestJSON::False),
+                    ("key-1".to_string(), TestJSON::Null),
                     ("key-2".to_string(), TestJSON::True),
                 ]),
             ]),
@@ -1383,27 +1382,7 @@ mod tests {
             ]),
             Path::from_vec(vec![1, 1]),
         );
-        */
-        run_test_ok(
-            TestJSON::Object(vec![
-                ("key-1".to_string(), TestJSON::False),
-                ("key-2".to_string(), TestJSON::True),
-            ]),
-            Path::from_vec(vec![1, 1]),
-            Action::Replace('n'),
-            (
-                false,
-                Ok(EditSuccess::Replace {
-                    c: 'n',
-                    name: "null".to_string(),
-                }),
-            ),
-            TestJSON::Object(vec![
-                ("key-1".to_string(), TestJSON::False),
-                ("key-2".to_string(), TestJSON::Null),
-            ]),
-            Path::from_vec(vec![1, 1]),
-        );
+
         run_test_err(
             TestJSON::Object(vec![
                 ("key-1".to_string(), TestJSON::False),

--- a/src/editor/dag.rs
+++ b/src/editor/dag.rs
@@ -389,8 +389,9 @@ impl<'arena, Node: Ast<'arena>> DAG<'arena, Node> {
                         }
                     }
                 }
-                let new_node = cursor.from_char(c).ok_or(EditErr::CharNotANode(c))?;
-
+                // Create the node to replace
+                // we can use unwrap here, because 'c' is always one of valid chars.
+                let new_node = cursor.from_char(c).unwrap();
                 let new_node_name = new_node.display_name();
                 Ok((
                     new_node,
@@ -428,11 +429,9 @@ impl<'arena, Node: Ast<'arena>> DAG<'arena, Node> {
                         }
                     }
                 }
-
                 // Create the node to insert
-                let new_node = this
-                    .arena
-                    .alloc(cursor.from_char(c).ok_or(EditErr::CharNotANode(c))?);
+                // we can use unwrap here, because 'c' is always one of valid chars.
+                let new_node = this.arena.alloc(cursor.from_char(c).unwrap());
                 let new_node_name = new_node.display_name();
                 // Clone the node that currently is the cursor, and add the new child to the end of its
                 // children.

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -108,7 +108,7 @@ impl<'arena, Node: Ast<'arena> + 'arena> Editor<'arena, Node> {
                     col = size.last_line_length();
                 }
             }};
-        };
+        }
 
         for (node, tok) in self.tree.root().display_tokens(&self.format_style) {
             match tok {


### PR DESCRIPTION
I  got the code working. But it's not that good.

Currently it has a problem:
When input is an invalid `char` , the error will return `EditErr::CannotBeChild`. 
I think it's better to return `EditErr::CharNotANode(char)`. It returns `EditErr::CharNotANode(char)` only when cursor is on root.

fixes #37 

Some tests are redundant, I will clean them up before this got merged.
