### PR TITLE
Port codebase to tui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +49,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "crossterm"
@@ -105,6 +124,15 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -230,6 +258,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +360,7 @@ dependencies = [
  "pretty_env_logger",
  "serde_json",
  "tui",
+ "tui-logger",
  "typed-arena",
 ]
 
@@ -361,6 +409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +439,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "tui"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +460,21 @@ dependencies = [
  "crossterm 0.18.2",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "tui-logger"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9173d7c096a3097f5e8432020bcdded1bef3ed57609466df3243b9db56d28b"
+dependencies = [
+ "chrono",
+ "fxhash",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "slog",
+ "tui",
 ]
 
 [[package]]
@@ -414,6 +494,12 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,18 +10,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,39 +27,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "blake2b_simd"
-version = "0.5.10"
+name = "cassowary"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cfg-if"
@@ -80,40 +45,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
+name = "crossterm"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "4e86d73f2a0b407b5768d10a8c720cf5d2df49a9efc10ca09176d201ead4b7fb"
 dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
+ "bitflags",
+ "crossterm_winapi 0.6.2",
  "lazy_static",
-]
-
-[[package]]
-name = "dirs"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
-dependencies = [
- "cfg-if 0.1.10",
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
-dependencies = [
  "libc",
- "redox_users",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c36c10130df424b2f3552fcc2ddcd9b28a27b1e54b358b45874f88d1ca6888c"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi 0.7.0",
+ "lazy_static",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2265c3f8e080075d9b6417aa72293fc71662f34b4af2612d8d1b074d29510db"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da8964ace4d3e4a044fd027919b2237000b24315a37c916f61809f1ff2140b9"
+dependencies = [
  "winapi",
 ]
 
@@ -128,17 +105,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -182,6 +148,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,9 +170,18 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.77"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f96b10ec2560088a8e76961b00d47107b3a625fecb76dedb29ee7ccbf98235"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
+
+[[package]]
+name = "lock_api"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -205,7 +189,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -215,16 +199,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
-name = "nix"
-version = "0.14.1"
+name = "mio"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
- "bitflags",
- "cc",
- "cfg-if 0.1.10",
  "libc",
- "void",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -245,19 +272,11 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
- "getrandom",
- "redox_syscall",
- "rust-argon2",
+ "bitflags",
 ]
 
 [[package]]
@@ -279,18 +298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,13 +307,20 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 name = "sapling"
 version = "0.1.0"
 dependencies = [
+ "crossterm 0.19.0",
  "hmap",
  "log",
  "pretty_env_logger",
  "serde_json",
- "tuikit",
+ "tui",
  "typed-arena",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
@@ -327,14 +341,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.6.1"
+name = "signal-hook"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
+checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
- "dirs",
- "winapi",
+ "libc",
+ "mio",
+ "signal-hook-registry",
 ]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "termcolor"
@@ -355,16 +385,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "tuikit"
-version = "0.4.5"
+name = "tui"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c628cfc5752254a33ebccf73eb79ef6508fab77de5d5ef76246b5e45010a51f"
+checksum = "9ced152a8e9295a5b168adc254074525c17ac4a83c90b2716274cc38118bddc9"
 dependencies = [
  "bitflags",
- "lazy_static",
- "log",
- "nix",
- "term",
+ "cassowary",
+ "crossterm 0.18.2",
+ "unicode-segmentation",
  "unicode-width",
 ]
 
@@ -375,22 +404,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,10 @@ authors = ["Ben White-Horne <kneasle@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-tuikit = "0.4.5"
 typed-arena = "2.0.1"
 hmap = "0.1.0"
 log = "0.4.14"
 pretty_env_logger = "0.4.0"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
+crossterm = "0.19.0"
+tui = { version = "0.14.0", default-features = false, features = ["crossterm"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ pretty_env_logger = "0.4.0"
 serde_json = { version = "1.0.64", features = ["preserve_order"] }
 crossterm = "0.19.0"
 tui = { version = "0.14.0", default-features = false, features = ["crossterm"] }
+tui-logger = "0.6.1"

--- a/README.md
+++ b/README.md
@@ -108,11 +108,6 @@ git clone https://github.com/kneasle/sapling.git
 cargo run 2> log
 ```
 
-Note that Sapling will not compile for Windows.  Windows support is absolutely intended, but Sapling
-currently uses [tuikit](https://github.com/lotabout/tuikit) as a terminal abstraction, which does
-not yet have Windows support.  PRs to Sapling or `tuikit` to add support for Windows would be very
-much appreciated.
-
 ### Current Keybindings
 
 #### Misc

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,8 @@ use crate::ast::display_token::{syntax_category::*, SyntaxCategory};
 use crate::core::Direction;
 use crate::editor::normal_mode::CmdType;
 
-use tuikit::prelude::{Color, Key};
+use crossterm::event::{KeyCode, KeyEvent};
+use tui::style::Color;
 
 /* DEBUG FLAGS */
 
@@ -23,17 +24,17 @@ pub type ColorScheme = std::collections::HashMap<SyntaxCategory, Color>;
 /// Return the default [`ColorScheme`] of Sapling
 pub fn default_color_scheme() -> ColorScheme {
     hmap::hmap! {
-        DEFAULT => Color::WHITE,
-        CONST => Color::RED,
-        LITERAL => Color::YELLOW,
-        COMMENT => Color::GREEN,
-        IDENT => Color::CYAN,
-        KEYWORD => Color::BLUE,
-        PRE_PROC => Color::MAGENTA,
-        TYPE => Color::LIGHT_YELLOW,
-        SPECIAL => Color::LIGHT_GREEN,
-        UNDERLINED => Color::LIGHT_RED,
-        ERROR => Color::LIGHT_RED
+        DEFAULT => Color::White,
+        CONST => Color::Red,
+        LITERAL => Color::Yellow,
+        COMMENT => Color::Green,
+        IDENT => Color::Cyan,
+        KEYWORD => Color::Black,
+        PRE_PROC => Color::Magenta,
+        TYPE => Color::LightYellow,
+        SPECIAL => Color::LightGreen,
+        UNDERLINED => Color::LightRed,
+        ERROR => Color::LightRed
     }
 }
 
@@ -41,26 +42,26 @@ pub fn default_color_scheme() -> ColorScheme {
 
 /// Mapping of keys to keystrokes.
 /// Shortcut definition, also allows us to change the type if needed.
-pub type KeyMap = std::collections::HashMap<Key, CmdType>;
+pub type KeyMap = std::collections::HashMap<KeyCode, CmdType>;
 
 /// Generates a 'canonical' [`KeyMap`].  These keybindings will be very similar to those of Vim.
 pub fn default_keymap() -> KeyMap {
     hmap::hmap! {
-        Key::Char('q') => CmdType::Quit,
-        Key::Char('w') => CmdType::Write,
-        Key::Char('i') => CmdType::InsertBefore,
-        Key::Char('a') => CmdType::InsertAfter,
-        Key::Char('o') => CmdType::InsertChild,
-        Key::Char('r') => CmdType::Replace,
-        Key::Char('x') => CmdType::Delete,
-        Key::Char('c') => CmdType::MoveCursor(Direction::Down),
-        Key::Char('p') => CmdType::MoveCursor(Direction::Up),
-        Key::Char('h') => CmdType::MoveCursor(Direction::Prev),
-        Key::Char('j') => CmdType::MoveCursor(Direction::Next),
-        Key::Char('k') => CmdType::MoveCursor(Direction::Prev),
-        Key::Char('l') => CmdType::MoveCursor(Direction::Next),
-        Key::Char('u') => CmdType::Undo,
-        Key::Char('R') => CmdType::Redo
+        KeyCode::Char('q') => CmdType::Quit,
+        KeyCode::Char('w') => CmdType::Write,
+        KeyCode::Char('i') => CmdType::InsertBefore,
+        KeyCode::Char('a') => CmdType::InsertAfter,
+        KeyCode::Char('o') => CmdType::InsertChild,
+        KeyCode::Char('r') => CmdType::Replace,
+        KeyCode::Char('x') => CmdType::Delete,
+        KeyCode::Char('c') => CmdType::MoveCursor(Direction::Down),
+        KeyCode::Char('p') => CmdType::MoveCursor(Direction::Up),
+        KeyCode::Char('h') => CmdType::MoveCursor(Direction::Prev),
+        KeyCode::Char('j') => CmdType::MoveCursor(Direction::Next),
+        KeyCode::Char('k') => CmdType::MoveCursor(Direction::Prev),
+        KeyCode::Char('l') => CmdType::MoveCursor(Direction::Next),
+        KeyCode::Char('u') => CmdType::Undo,
+        KeyCode::Char('R') => CmdType::Redo
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use crate::ast::display_token::{syntax_category::*, SyntaxCategory};
 use crate::core::Direction;
 use crate::editor::normal_mode::CmdType;
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::KeyCode;
 use tui::style::Color;
 
 /* DEBUG FLAGS */

--- a/src/core/key_display.rs
+++ b/src/core/key_display.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 
-use tuikit::prelude::Key;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 /// An extension trait to add a convenient way to display keystrokes
 pub trait KeyDisplay {
@@ -10,39 +10,47 @@ pub trait KeyDisplay {
     fn compact_string(self) -> Cow<'static, str>;
 }
 
-impl KeyDisplay for Key {
+impl KeyDisplay for KeyEvent {
     fn compact_string(self) -> Cow<'static, str> {
-        match self {
-            Key::Char(c) => Cow::from(String::from(c)),
-            Key::Ctrl(c) => Cow::from(format!("^{}", c)),
+        if self.modifiers.contains(KeyModifiers::CONTROL) {
+            if let KeyCode::Char(c) = self.code {
+                return Cow::from(format!("^{}", c));
+            }
+        }
+        if self.modifiers.is_empty() {
+            match self.code {
+                KeyCode::Char(c) => Cow::from(String::from(c)),
 
-            Key::Up => Cow::from("<Up>"),
-            Key::Down => Cow::from("<Down>"),
-            Key::Left => Cow::from("<Left>"),
-            Key::Right => Cow::from("<Right>"),
+                KeyCode::Up => Cow::from("<Up>"),
+                KeyCode::Down => Cow::from("<Down>"),
+                KeyCode::Left => Cow::from("<Left>"),
+                KeyCode::Right => Cow::from("<Right>"),
 
-            Key::F(num) => Cow::from(format!("<F{}>", num)),
-            Key::ESC => Cow::from("<Esc>"),
+                KeyCode::F(num) => Cow::from(format!("<F{}>", num)),
+                KeyCode::Esc => Cow::from("<Esc>"),
 
-            Key::Backspace => Cow::from("<BS>"),
-            Key::Delete => Cow::from("<Del>"),
+                KeyCode::Backspace => Cow::from("<BS>"),
+                KeyCode::Delete => Cow::from("<Del>"),
 
-            Key::Tab => Cow::from("<Tab>"),
-            Key::Enter => Cow::from("<CR>"),
+                KeyCode::Tab => Cow::from("<Tab>"),
+                KeyCode::Enter => Cow::from("<CR>"),
 
-            Key::Insert => Cow::from("<Insert>"),
-            Key::Home => Cow::from("<Home>"),
-            Key::End => Cow::from("<End>"),
-            Key::PageUp => Cow::from("<PageUp>"),
-            Key::PageDown => Cow::from("<PageDown>"),
+                KeyCode::Insert => Cow::from("<Insert>"),
+                KeyCode::Home => Cow::from("<Home>"),
+                KeyCode::End => Cow::from("<End>"),
+                KeyCode::PageUp => Cow::from("<PageUp>"),
+                KeyCode::PageDown => Cow::from("<PageDown>"),
 
-            _ => Cow::from(format!("{:?}", self)),
+                _ => Cow::from(format!("{:?}", self)),
+            }
+        } else {
+            Cow::from(format!("{:?}", self))
         }
     }
 }
 
 /// converts a `Key`s keystroke_buffer into a `String`
-pub fn keystrokes_to_string(keystroke_buffer: &[Key]) -> String {
+pub fn keystrokes_to_string(keystroke_buffer: &[KeyEvent]) -> String {
     keystroke_buffer
         .iter()
         .map(|x| x.compact_string())

--- a/src/editor/keystroke_log.rs
+++ b/src/editor/keystroke_log.rs
@@ -7,7 +7,12 @@ use crate::core::keystrokes_to_string;
 use super::normal_mode::Action;
 
 use crossterm::event::KeyEvent;
-use tui::{buffer::Buffer, layout::{Constraint, Rect}, style::{Color, Style}, widgets::{Cell, Row, Table, Widget}};
+use tui::{
+    buffer::Buffer,
+    layout::{Constraint, Rect},
+    style::{Color, Style},
+    widgets::{Cell, Row, Table, Widget},
+};
 
 /// A category grouping similar actions
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -74,6 +79,7 @@ pub struct KeyStrokeLog {
     /// The keystrokes that will be included in the next log entry
     unlogged_keystrokes: Vec<KeyEvent>,
 }
+
 impl Widget for &'_ KeyStrokeLog {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let rows_displayed = self
@@ -102,6 +108,7 @@ impl Widget for &'_ KeyStrokeLog {
         .render(area, buf);
     }
 }
+
 impl KeyStrokeLog {
     /// Create a new (empty) keystroke log
     pub fn new(max_entries: usize) -> KeyStrokeLog {

--- a/src/editor/state.rs
+++ b/src/editor/state.rs
@@ -5,7 +5,7 @@ use crate::ast::Ast;
 
 use std::borrow::Cow;
 
-use tuikit::prelude::Key;
+use crossterm::event::KeyEvent;
 
 /// The [`State`] that Sapling enters to quit the mainloop and exit
 #[derive(Debug, Copy, Clone)]
@@ -14,7 +14,7 @@ pub struct Quit;
 impl<'arena, Node: Ast<'arena>> State<'arena, Node> for Quit {
     fn transition(
         self: Box<Self>,
-        _key: Key,
+        _key: KeyEvent,
         _editor: &mut Editor<'arena, Node>,
     ) -> (Box<dyn State<'arena, Node>>, Option<(String, Category)>) {
         (self, None)
@@ -35,7 +35,7 @@ pub trait State<'arena, Node: Ast<'arena>>: std::fmt::Debug {
     /// Consume a keystroke, returning the `State` after this transition
     fn transition(
         self: Box<Self>,
-        key: Key,
+        key: KeyEvent,
         editor: &mut Editor<'arena, Node>,
     ) -> (Box<dyn State<'arena, Node>>, Option<(String, Category)>);
 

--- a/src/editor/widgets.rs
+++ b/src/editor/widgets.rs
@@ -1,0 +1,111 @@
+use crate::ast::{Ast, display_token::{DisplayToken, SyntaxCategory}};
+use super::DEBUG_HIGHLIGHTING;
+
+use std::hash::Hasher;
+use std::collections::{hash_map::DefaultHasher, HashSet};
+
+use tui::{buffer::Buffer, layout::{Alignment, Rect}, style::{Color, Style}, widgets::{Paragraph, Widget}};
+
+pub struct StatusBar<'a> {
+    pub keystroke_buffer: &'a str,
+}
+impl Widget for StatusBar<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        Paragraph::new(self.keystroke_buffer)
+            .alignment(Alignment::Right)
+            .render(area, buf);
+        buf.set_string(area.x, area.y, "Press 'q' to exit", Style::default());
+    }
+}
+
+pub struct TextView<'a, 'arena, Node: Ast<'arena>> {
+    pub tree: &'a super::Dag<'arena, Node>,
+    pub color_scheme: &'a super::config::ColorScheme,
+    pub format_style: &'a Node::FormatStyle,
+}
+impl<'arena, Node: Ast<'arena>> Widget for TextView<'_, 'arena, Node> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let cols = [
+            Color::Magenta,
+            Color::Red,
+            Color::Yellow,
+            Color::Gray,
+            Color::Cyan,
+            Color::Blue,
+            Color::White,
+            Color::LightRed,
+            Color::LightBlue,
+            Color::LightCyan,
+            Color::LightGreen,
+            Color::LightYellow,
+            Color::LightMagenta,
+        ];
+
+        /* RENDER MAIN TEXT VIEW */
+        // Mutable variables to track where the terminal cursor should go
+        let mut row = area.top();
+        let mut col = area.left();
+        let mut indentation_amount = 0;
+
+        let mut unknown_categories: HashSet<SyntaxCategory> = HashSet::with_capacity(0);
+
+        for (node, tok) in self.tree.root().display_tokens(self.format_style) {
+            match tok {
+                DisplayToken::Text(s, category) => {
+                    let color = if DEBUG_HIGHLIGHTING {
+                        // Hash the ref to decide on the colour
+                        let mut hasher = DefaultHasher::new();
+                        node.hash(&mut hasher);
+                        let hash = hasher.finish();
+                        cols[hash as usize % cols.len()]
+                    } else {
+                        *self.color_scheme.get(category).unwrap_or_else(|| {
+                            unknown_categories.insert(category);
+                            &Color::LightMagenta
+                        })
+                    };
+                    // Generate the display attributes depending on if the node is selected
+                    let style = if std::ptr::eq(node, self.tree.cursor()) {
+                        Style::default().fg(Color::Black).bg(color)
+                    } else {
+                        Style::default().fg(color)
+                    };
+                    let mut lines = s.lines();
+                    col = buf
+                        .set_stringn(
+                            col,
+                            row,
+                            lines.next().unwrap(),
+                            (area.right() - col).into(),
+                            style,
+                        )
+                        .0;
+                    for _ in lines {
+                        todo!("implement multiline tokens");
+                    }
+                }
+                DisplayToken::Whitespace(n) => {
+                    col += n as u16;
+                }
+                DisplayToken::Newline => {
+                    row += 1;
+                    if row == area.bottom() {
+                        break;
+                    }
+                    col = indentation_amount;
+                }
+                DisplayToken::Indent => {
+                    indentation_amount += 4;
+                }
+                DisplayToken::Dedent => {
+                    indentation_amount -= 4;
+                }
+            }
+        }
+
+        // Print warning messages for unknown syntax categories
+        for c in unknown_categories {
+            log::error!("Unknown highlight category '{}'", c);
+        }
+    }
+}

--- a/src/editor/widgets.rs
+++ b/src/editor/widgets.rs
@@ -1,10 +1,18 @@
-use crate::ast::{Ast, display_token::{DisplayToken, SyntaxCategory}};
 use super::DEBUG_HIGHLIGHTING;
+use crate::ast::{
+    display_token::{DisplayToken, SyntaxCategory},
+    Ast,
+};
 
-use std::hash::Hasher;
 use std::collections::{hash_map::DefaultHasher, HashSet};
+use std::hash::Hasher;
 
-use tui::{buffer::Buffer, layout::{Alignment, Rect}, style::{Color, Style}, widgets::{Paragraph, Widget}};
+use tui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::{Color, Style},
+    widgets::{Paragraph, Widget},
+};
 
 pub struct StatusBar<'a> {
     pub keystroke_buffer: &'a str,
@@ -20,7 +28,7 @@ impl Widget for StatusBar<'_> {
 
 pub struct TextView<'a, 'arena, Node: Ast<'arena>> {
     pub tree: &'a super::Dag<'arena, Node>,
-    pub color_scheme: &'a super::config::ColorScheme,
+    pub color_scheme: &'a crate::config::ColorScheme,
     pub format_style: &'a Node::FormatStyle,
 }
 impl<'arena, Node: Ast<'arena>> Widget for TextView<'_, 'arena, Node> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,9 +28,9 @@ use serde_json::Value;
 /// [`Editor::run`].
 fn main() {
     // Initialise the logging and startup
-    pretty_env_logger::formatted_builder()
-        .filter_level(log::LevelFilter::Debug)
-        .init();
+    // pretty_env_logger::formatted_builder()
+    //     .filter_level(log::LevelFilter::Debug)
+    //     .init();
     log::info!("Starting up...");
 
     // Read a file name as the CLI argument

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,9 +28,7 @@ use serde_json::Value;
 /// [`Editor::run`].
 fn main() {
     // Initialise the logging and startup
-    // pretty_env_logger::formatted_builder()
-    //     .filter_level(log::LevelFilter::Debug)
-    //     .init();
+    tui_logger::init_logger(log::LevelFilter::Info).unwrap();
     log::info!("Starting up...");
 
     // Read a file name as the CLI argument


### PR DESCRIPTION
Windows support is the primary motivation here, but the `tui` crate is also used much more widely in the ecosystem and provides some handy abstractions.

I've kept changes in this PR to a minimum, replacing `tuikit` calls with their closest `tui` equivalents. There's probably more that could be done to make the code more idiomatic `tui` code.