### PR TITLE
Fix a small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ interested.  There's also a discord server for discussions about Sapling and str
 general ([invite link](https://discord.gg/Amv3Tsb4fV)). OK enough from me, onto the real README!_
 
 Most of the ideas for this project come from my friend Shtanton's
-[blog post](http://shtanton.com/ex.html).  The concept of directly editing syntax trees is called
+[blog post](http://shtanton.com/posts/ex.html).  The concept of directly editing syntax trees is called
 ['structured editing'](https://en.wikipedia.org/wiki/Structure_editor) and is not new;
 the purpose of Sapling is to use ideas from structured editing to **speed up** moment-to-moment
 code editing, much how editors like Vim and Emacs speed up editing.  Sapling's editing model will


### PR DESCRIPTION
The README.md has a link out which needed updating. 